### PR TITLE
releaseタグがpushされたとき、Linux向けのリリースバイナリを作って公開する

### DIFF
--- a/.github/workflows/add-release-tag.yml
+++ b/.github/workflows/add-release-tag.yml
@@ -1,0 +1,21 @@
+name: add release tag
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  release:
+    name: add tag
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: add release tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMIT: ${{ github.sha }}
+        run: sh ${GITHUB_WORKSPACE}/github/scripts/add-tag.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+on:
+  push:
+    tags:
+      - 'release-*'
+
+name: build and release stable version
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Release build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: Zip binary for Linux(x86_64)
+        run: |
+          zip cece-linux-x86_64 target/release/cece
+      - name: Store zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-linux
+          path: cece-linux-x86_64.zip
+
+  create-release:
+    needs: [build-linux]
+    runs-on: ubuntu-20.04
+    steps:
+      - id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: true
+      - run: |
+          echo '${{ steps.create-release.outputs.upload_url }}' > release_upload_url.txt
+      - uses: actions/upload-artifact@v1
+        with:
+          name: create-release
+          path: release_upload_url.txt
+
+  publish-release:
+    needs: [create-release]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: create-release
+      - id: upload-url
+        run: |
+          echo "::set-output name=url::$(cat create-release/release_upload_url.txt)"
+      - uses: actions/download-artifact@v1
+        with:
+          name: build-linux
+      - name: check current directory
+        run: |
+          ls -a ./build-linux
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.upload-url.outputs.url }}
+          asset_path: ./build-linux/cece-linux-x86_64.zip
+          asset_name: cece-linux-x86_64.zip
+          asset_content_type: application/zip

--- a/github/scripts/add-tag.sh
+++ b/github/scripts/add-tag.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "{\"ref\":\"refs/tags/release-$(date +"%Y%m%d-%H%m")\",\"sha\":\"$COMMIT\"}" | \
+curl -s -X POST "https://api.github.com/repos/${REPO}/git/refs" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -d @-


### PR DESCRIPTION
## 問題点
- 現状バイナリを公開しておらず、使いたい人が自前でビルドしないといけないので、バイナリを公開できるようにする

## やったこと
- 以下を作った
  - タグを見てreleaseを作るActions
  - masterにマージされたらreleaseタグを作るActions

## 使い方
```sh
$ git tag release-{なんかいい感じのリリース名とか}
$ git push origin {tag名}
```

## ひとこと
- うまいこと連動して走ってくれればよかったけどそうできなかったので、別途対応たのんだ